### PR TITLE
Add Past logs indexer

### DIFF
--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -1,11 +1,14 @@
 import "fake-indexeddb/auto";
+import {decodeEventLog, DecodeEventLogReturnType, Log} from "viem";
 import {LiveIndexer} from "@/lib/indexer/live";
-import {Log} from "viem";
-export class EVMIndex extends LiveIndexer {
+import {PastIndexer} from "@/lib/indexer/past";
+export class EVMIndex {
+
+    private rpc: string;
     constructor(
         rpc: string
     ) {
-        super(rpc);
+        this.rpc = rpc;
     }
 
     public async addLiveSync(
@@ -14,13 +17,49 @@ export class EVMIndex extends LiveIndexer {
         callback: (logs: Log[]) => void
     ): Promise<void> {
         try {
+            const liveIndexer = new LiveIndexer(this.rpc);
             console.log(`[Live Sync] Indexing ${address} for ${event} events`);
-            await this.watchEvent(address, event, callback)
+            await liveIndexer.watchEvent(address, event, callback)
             return;
         } catch (e: unknown) {
             console.log(`[Live Sync] Failed to index ${address} for ${event} events`);
             console.log(e);
         }
+    }
+
+    public async syncPastLogs(
+        address: `0x${string}`,
+        event: string,
+    ): Promise<Log[] | undefined> {
+        try {
+            const pastIndexer = new PastIndexer(this.rpc);
+            console.log(`[Past Sync] Indexing ${address} for ${event} events`);
+            return pastIndexer.getPastLogs({
+                address,
+                event,
+                fromBlock: 32228054,
+                toBlock: 43432175
+            })
+        } catch (e: unknown) {
+            console.log(`[Past Sync] Failed to index ${address} for ${event} events`);
+            console.log(e);
+        }
+    }
+
+    static decodeEventLogs(
+        abi: any,
+        logs: Log[]
+    ): (Log & DecodeEventLogReturnType)[] {
+        return logs.map((log) => {
+            return {
+                ...log,
+                ...decodeEventLog({
+                    abi,
+                    data: log.data,
+                    topics: log.topics
+                })
+            }
+        })
     }
 
 }

--- a/packages/indexer/src/lib/indexer/live.ts
+++ b/packages/indexer/src/lib/indexer/live.ts
@@ -9,7 +9,7 @@ export class LiveIndexer extends Provider {
         super(rpc);
     }
 
-    protected async watchEvent(
+    public async watchEvent(
         address: `0x${string}`,
         event: string,
         logsHandler: (logs: Log[]) => void

--- a/packages/indexer/src/lib/indexer/past.ts
+++ b/packages/indexer/src/lib/indexer/past.ts
@@ -1,0 +1,34 @@
+import {Provider} from "@/lib/provider";
+import {Log, parseAbiItem} from "viem";
+
+type PastLogsParams = {
+    address: `0x${string}`,
+    event: string,
+    fromBlock: number,
+    toBlock: number
+}
+
+export class PastIndexer extends Provider {
+    constructor(rpc: string) {
+        super(rpc);
+    }
+
+    async getPastLogs(params: PastLogsParams): Promise<Log[] | undefined> {
+        const {address, event, fromBlock, toBlock} = params
+
+        if(fromBlock > toBlock) {
+            throw new Error(`Invalid block range: ${fromBlock} > ${toBlock}`);
+        }
+
+        if(fromBlock < 0) {
+            throw new Error(`Syncing from genesis block is not supported yet, please specify a block number greater than 0`);
+        }
+
+        return this.getClient().getLogs({
+            address,
+            event: parseAbiItem(event) as any,
+            fromBlock: BigInt(fromBlock),
+            toBlock: BigInt(toBlock),
+        })
+    }
+}


### PR DESCRIPTION
- [x] Add singleton provider class to reuse the same client
- [x] Add a Past indexer to return for past events logs within the specified from and to block range
- [x] Provide a static method to decode logs