### PR TITLE
Fix/incorrect past sync params

### DIFF
--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evmindex",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "**EVMIndex** is a plug-and-play blockchain indexer for EVM chains, designed to simplify the process of indexing and retrieving blockchain data. With **EVMIndex**, you can easily set up your own EVM chain indexer on your infrastructure and use simple APIs to retrieve the indexed data.",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/indexer/src/config/provider.ts
+++ b/packages/indexer/src/config/provider.ts
@@ -1,8 +1,0 @@
-import { ethers } from 'ethers'
-import dotenv from 'dotenv'
-import { workerData } from 'worker_threads'
-
-dotenv.config()
-export const Provider = new ethers.providers.JsonRpcProvider(
-  workerData?.providerURL
-)

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -2,6 +2,7 @@ import 'fake-indexeddb/auto'
 import { decodeEventLog, DecodeEventLogReturnType, Log } from 'viem'
 import { LiveIndexer } from '@/lib/indexer/live'
 import { PastIndexer } from '@/lib/indexer/past'
+import {PastLogsParams} from "@/types";
 export class EVMIndex {
   private rpc: string
   constructor(rpc: string) {
@@ -24,18 +25,16 @@ export class EVMIndex {
     }
   }
 
-  public async syncPastLogs(
-    address: `0x${string}`,
-    event: string
-  ): Promise<Log[] | undefined> {
+  public async syncPastLogs(params: PastLogsParams): Promise<Log[] | undefined> {
+    const {event, toBlock, fromBlock, address} = params
     try {
       const pastIndexer = new PastIndexer(this.rpc)
       console.log(`[Past Sync] Indexing ${address} for ${event} events`)
       return pastIndexer.getPastLogs({
         address,
         event,
-        fromBlock: 32228054,
-        toBlock: 43432175,
+        fromBlock,
+        toBlock,
       })
     } catch (e: unknown) {
       console.log(`[Past Sync] Failed to index ${address} for ${event} events`)

--- a/packages/indexer/src/lib/indexer/past.ts
+++ b/packages/indexer/src/lib/indexer/past.ts
@@ -1,12 +1,6 @@
 import { Provider } from '@/lib/provider'
 import { Log, parseAbiItem } from 'viem'
-
-type PastLogsParams = {
-  address: `0x${string}`
-  event: string
-  fromBlock: number
-  toBlock: number
-}
+import {PastLogsParams} from "@/types";
 
 export class PastIndexer extends Provider {
   constructor(rpc: string) {

--- a/packages/indexer/src/types/index.ts
+++ b/packages/indexer/src/types/index.ts
@@ -1,16 +1,3 @@
-import { Contract as EthersContract } from 'ethers'
-
-export type HandlerFn = (ctx: unknown) => Promise<void>
-
-export type EventHandler = {
-  event: string
-  handler: string | HandlerFn
-  webhook?: string
-  file: string
-  confirmations?: number
-  eventArgs: string[]
-}
-
 export type ContractOptions = {
   name: string
   address: string
@@ -27,8 +14,9 @@ export type Config = {
   config: ContractOptions[]
 }
 
-export type Listener = {
-  contract: EthersContract
-  address: string
-  events: Omit<EventHandler, 'file'>[]
+export type PastLogsParams = {
+  address: `0x${string}`
+  event: string
+  fromBlock: number
+  toBlock: number
 }


### PR DESCRIPTION
1. Fix hardcoded past sync method params such as `fromBlock` and `toblock`
2. Remove ethers config, thereby removing complete ethers dependencies