### PR TITLE
Run callback fn and pass the log chunks before going to sleep

### DIFF
--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "evmindex",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "**EVMIndex** is a plug-and-play blockchain indexer for EVM chains, designed to simplify the process of indexing and retrieving blockchain data. With **EVMIndex**, you can easily set up your own EVM chain indexer on your infrastructure and use simple APIs to retrieve the indexed data.",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/indexer/src/index.ts
+++ b/packages/indexer/src/index.ts
@@ -1,6 +1,6 @@
 import 'fake-indexeddb/auto'
 import { decodeEventLog, DecodeEventLogReturnType, Log } from 'viem'
-import { LiveIndexer } from "./lib/indexer/live"
+import { LiveIndexer } from './lib/indexer/live'
 import { PastIndexer } from './lib/indexer/past'
 import { PastLogsParams } from './types'
 export class EVMIndex {

--- a/packages/indexer/src/lib/indexer/past.ts
+++ b/packages/indexer/src/lib/indexer/past.ts
@@ -1,8 +1,8 @@
 import { Provider } from '../../lib/provider'
 import { Log, parseAbiItem } from 'viem'
 import { PastLogsParams } from '../../types'
-import {PAST_SYNC_BLOCK_LIMIT} from "../../utils/constants";
-import {sleep} from "../../utils/sleep";
+import { PAST_SYNC_BLOCK_LIMIT } from '../../utils/constants'
+import { sleep } from '../../utils/sleep'
 
 export class PastIndexer extends Provider {
   constructor(rpc: string) {
@@ -31,16 +31,16 @@ export class PastIndexer extends Provider {
       const from = fromBlock + i * PAST_SYNC_BLOCK_LIMIT
       const to = Math.min(fromBlock + (i + 1) * PAST_SYNC_BLOCK_LIMIT, toBlock)
 
-      const logsChunk = await this.getClient().getLogs({
+      const logsChunk = (await this.getClient().getLogs({
         address,
         event: parseAbiItem(event) as any,
         fromBlock: BigInt(from),
         toBlock: BigInt(to),
-      }) as any
+      })) as any
 
       const logsChunkWithTimestamp: Log[] = []
 
-      for(const log of logsChunk) {
+      for (const log of logsChunk) {
         const block = await this.getClient().getBlock({
           blockNumber: BigInt(log.blockNumber),
         })
@@ -50,6 +50,9 @@ export class PastIndexer extends Provider {
       }
 
       logs.push(...logsChunkWithTimestamp)
+      if (params.cb) {
+        params.cb(logsChunkWithTimestamp)
+      }
       console.log(`=====================`)
       console.log(`[Past Sync] Synced ${logs.length} logs`)
       console.log(`[Past Sync] ${requests - i} requests left`)

--- a/packages/indexer/src/types/index.ts
+++ b/packages/indexer/src/types/index.ts
@@ -1,3 +1,5 @@
+import { Log } from 'viem'
+
 export type ContractOptions = {
   name: string
   address: string
@@ -19,4 +21,5 @@ export type PastLogsParams = {
   event: string
   fromBlock: number
   toBlock: number
+  cb?: (logs: Log[]) => void
 }

--- a/packages/indexer/src/utils/constants.ts
+++ b/packages/indexer/src/utils/constants.ts
@@ -1,1 +1,1 @@
-export const PAST_SYNC_BLOCK_LIMIT = 1500;
+export const PAST_SYNC_BLOCK_LIMIT = 1500

--- a/packages/indexer/src/utils/sleep.ts
+++ b/packages/indexer/src/utils/sleep.ts
@@ -1,1 +1,2 @@
-export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+export const sleep = (ms: number) =>
+  new Promise((resolve) => setTimeout(resolve, ms))


### PR DESCRIPTION
Since the past sync sleeps after every 1500 requests, there is a bug that used to lose all the data by the time it reached the end of the loop, hence we'll call a callback every time with the log chunks before the past sync sleeps. 